### PR TITLE
Support empty documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "MIT",
   "main": "src/index",
   "files": [

--- a/src/consent-manager.tsx
+++ b/src/consent-manager.tsx
@@ -64,7 +64,7 @@ export const injectConsentManagerApp = (
       );
 
       // Append UI container to doc to activate style.sheet
-      document.documentElement.append(consentManager);
+      (document.documentElement || document).append(consentManager);
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       style


### PR DESCRIPTION
Whenever `transcend.io` is in a TCM bundle's allowed domains list, we end up injecting airgap.js into the TCM sync frame. The TCM sync frame contains an 'empty' document post-load, and this UI is trying to call `null.append()` in that case.

We also made a change upstream for airgap.js to prevent this from happening for our sync endpoints.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
