### PR TITLE
Always infer prompt dismissal & privacy regimes at runtime using airgap.js APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "1.0.22",
+  "version": "1.0.24",
   "license": "MIT",
   "main": "src/index",
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "MIT",
   "main": "src/index",
   "files": [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -52,10 +52,11 @@ export default function App({
   const { initialViewStateByPrivacyRegime, dismissedViewState } = config;
   const initialViewState: ViewState =
     initialViewStateByPrivacyRegime[privacyRegime];
-  const { viewState, handleSetViewState, wasDismissed } = useViewState({
+  const { viewState, handleSetViewState } = useViewState({
     initialViewState,
     dismissedViewState,
   });
+  const confirmed = !!window?.airgap?.getConsent?.()?.confirmed;
 
   // Set whether we're in opt-in consent mode or give-notice mode
   const mode =
@@ -69,7 +70,7 @@ export default function App({
       hideConsentManager: () => handleSetViewState('close'),
       toggleConsentManager: () =>
         handleSetViewState(viewStateIsClosed(viewState) ? 'open' : 'close'),
-      autoShowConsentManager: () => !wasDismissed && handleSetViewState('open'),
+      autoShowConsentManager: () => !confirmed && handleSetViewState('open'),
     };
 
     // Trigger event handler for this event

--- a/src/hooks/useRegime.ts
+++ b/src/hooks/useRegime.ts
@@ -1,5 +1,5 @@
 // external
-import { useEffect } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 // main
 import {
@@ -8,9 +8,6 @@ import {
   PrivacyRegimeEnum,
 } from '@transcend-io/airgap.js-types';
 
-// local
-import { useStickyState } from './useStickyState';
-
 /**
  * Set the privacy regime to use
  *
@@ -18,9 +15,8 @@ import { useStickyState } from './useStickyState';
  * @returns the PrivacyRegime or null if there is no applicable regime
  */
 export function useRegime(airgap: AirgapAPI): PrivacyRegime {
-  const [privacyRegime, setPrivacyRegime] = useStickyState<PrivacyRegimeEnum>(
+  const [privacyRegime, setPrivacyRegime] = useState<PrivacyRegimeEnum>(
     PrivacyRegimeEnum.Unknown,
-    'tcmPrivacyRegime',
   );
 
   useEffect(() => {

--- a/src/hooks/useViewState.ts
+++ b/src/hooks/useViewState.ts
@@ -1,5 +1,5 @@
 // external
-import { useCallback } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 
 // main
 import {
@@ -11,9 +11,6 @@ import {
 // global
 import { logger } from '../logger';
 import type { HandleSetViewState, RequestedViewState } from '../types';
-
-// local
-import { useStickyState } from './useStickyState';
 
 /**
  * Helper to determine whether a view state is closed
@@ -49,24 +46,16 @@ export function useViewState({
   viewState: ViewState;
   /** A handler for the view state */
   handleSetViewState: HandleSetViewState;
-  /** A flag for whether the consent manager has been dismissed */
-  wasDismissed: boolean;
 } {
-  const [state, setState] = useStickyState<{
+  const [state, setState] = useState<{
     /** The current view state */
     current: ViewState;
     /** The previous view state - used for going back */
     previous: ViewState | null;
-    /** A flag for whether the consent manager has been dismissed (used by autoShowConsentManager) */
-    wasDismissed: boolean;
-  }>(
-    {
-      current: ViewState.Hidden,
-      previous: null,
-      wasDismissed: false,
-    },
-    'tcmViewState',
-  );
+  }>({
+    current: ViewState.Hidden,
+    previous: null,
+  });
 
   /**
    * When the viewState is set, update the view state and track previous state + whether the modal has (ever) been dismissed
@@ -82,7 +71,6 @@ export function useViewState({
             setState({
               current: state.previous,
               previous: state.current,
-              wasDismissed: state.wasDismissed,
             });
           } else {
             logger.warn('Tried to go back when there is no previous state');
@@ -94,7 +82,6 @@ export function useViewState({
           setState({
             current: initialViewState,
             previous: state.current,
-            wasDismissed: state.wasDismissed,
           });
           break;
 
@@ -103,7 +90,6 @@ export function useViewState({
           setState({
             current: dismissedViewState,
             previous: state.current,
-            wasDismissed: true,
           });
           break;
 
@@ -112,11 +98,6 @@ export function useViewState({
           setState({
             current: requestedViewState,
             previous: state.current,
-            wasDismissed:
-              state.wasDismissed ||
-              Object.values<ViewState>(DismissedViewState).includes(
-                requestedViewState,
-              ),
           });
           break;
       }
@@ -127,6 +108,5 @@ export function useViewState({
   return {
     viewState: state.current,
     handleSetViewState,
-    wasDismissed: state.wasDismissed,
   };
 }


### PR DESCRIPTION
With this change, view state and regimes no longer need StickyStates. This makes it easier to test regimes and makes prompt dismissal management stateless.

## Related Issues

- Closes https://transcend.height.app/T-12130

## Security Implications

_[none]_

## System Availability

_[none]_
