### PR TITLE
Removes `mode` prop to make regime and view state more independent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       data-cfasync="false"
       data-ui="http://localhost:8080/build/ui.js"
       src="https://cdn.transcend.io/cm/443312ef-12f9-494d-85f5-969894260cc7/airgap.js"
-      data-regime="CPRA"
+      data-regime="GDPR"
     ></script>
   </head>
 

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       data-cfasync="false"
       data-ui="http://localhost:8080/build/ui.js"
       src="https://cdn.transcend.io/cm/443312ef-12f9-494d-85f5-969894260cc7/airgap.js"
+      data-regime="CPRA"
     ></script>
   </head>
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "license": "MIT",
   "main": "src/index",
   "files": [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -62,9 +62,6 @@ export default function App({
     initialViewState,
     dismissedViewState,
   });
-  // Set whether we're in opt-in consent mode or give-notice mode
-  const mode =
-    initialViewState === ViewState.NoticeAndDoNotSell ? 'NOTICE' : 'CONSENT';
 
   // Event listener for the API
   appContainer.addEventListener(apiEventName, (event) => {
@@ -133,7 +130,6 @@ export default function App({
           <AirgapProvider newAirgap={airgap}>
             <Main
               viewState={viewState}
-              mode={mode}
               handleSetViewState={handleSetViewState}
               handleChangeLanguage={handleChangeLanguage}
             />

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -52,7 +52,6 @@ export default function BottomMenu({
     <div className={cx(menuContainerStyle)}>
       {![
         ViewState.NoticeAndDoNotSell,
-        ViewState.DoNotSellAcknowledgement,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ].includes(viewState as any) && (
         <div className={cx(menuItemContainerStyle)}>

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -18,13 +18,10 @@ import MenuItem from './MenuItem';
  */
 export default function BottomMenu({
   viewState,
-  mode,
   handleSetViewState,
 }: {
   /** The current viewState */
   viewState: ViewState;
-  /** Whether we're in opt-in consent mode or give-notice mode */
-  mode: 'CONSENT' | 'NOTICE';
   /** Function to change viewState */
   handleSetViewState: HandleSetViewState;
 }): JSX.Element {
@@ -53,7 +50,11 @@ export default function BottomMenu({
 
   return (
     <div className={cx(menuContainerStyle)}>
-      {mode === 'CONSENT' && (
+      {![
+        ViewState.NoticeAndDoNotSell,
+        ViewState.DoNotSellAcknowledgement,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ].includes(viewState as any) && (
         <div className={cx(menuItemContainerStyle)}>
           {viewState === ViewState.CompleteOptions ? (
             <MenuItem
@@ -77,7 +78,7 @@ export default function BottomMenu({
         </div>
       )}
 
-      {mode === 'NOTICE' && (
+      {viewState === ViewState.NoticeAndDoNotSell && (
         <div className={cx(menuItemContainerStyle)}>
           <MenuItem
             label={formatMessage(noticeAndDoNotSellMessages.doNotSellLabel)}

--- a/src/components/GPCIndicator.tsx
+++ b/src/components/GPCIndicator.tsx
@@ -9,6 +9,7 @@ import type { AirgapAPI } from '@transcend-io/airgap.js-types';
 import { useAirgap, useConfig, useEmotion } from '../hooks';
 import { completeOptionsMessages } from '../messages';
 import { getPrimaryRegime } from '../regimes';
+import { NavigatorWithGPC } from '../types';
 
 /**
  * Helper to get the current sale of info setting
@@ -19,14 +20,6 @@ function getSaleOfInfoIsOn(airgap: AirgapAPI): boolean {
   const purpose = 'SaleOfInfo';
   return !!consent.purposes[purpose];
 }
-
-/**
- * Type override for new GPC standard (not in official DOM spec yet)
- */
-type NavigatorWithGPC = Navigator & {
-  /** see https://globalprivacycontrol.github.io/gpc-spec/ */
-  globalPrivacyControl: boolean;
-};
 
 /**
  * Indicator that the Global Privacy Control signal is controlling this setting

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -26,14 +26,11 @@ import QuickOptions from './QuickOptions';
  */
 export default function Main({
   viewState,
-  mode,
   handleSetViewState,
   handleChangeLanguage,
 }: {
   /** The current viewState of the consent manager */
   viewState: ViewState;
-  /** Whether we're in opt-in consent mode or give-notice mode */
-  mode: 'CONSENT' | 'NOTICE';
   /** Updater function for viewState */
   handleSetViewState: HandleSetViewState;
   /** Updater function for language change */
@@ -80,7 +77,6 @@ export default function Main({
           <FullLogo />
           <BottomMenu
             viewState={viewState}
-            mode={mode}
             handleSetViewState={handleSetViewState}
           />
           <LanguageButton

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ const defaultConfig: ConsentManagerConfig = {
   },
   initialViewStateByPrivacyRegime: {
     // California
+    // TODO: https://transcend.height.app/T-17251 - migrate to DoNotSellAcknowledgement
     CPRA: ViewState.NoticeAndDoNotSell,
     // EU
     GDPR: ViewState.QuickOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,3 +61,11 @@ export interface EmitEventOptions extends ShowConsentManagerOptions {
   /** Type of event being emitted */
   eventType: keyof ConsentManagerAPI;
 }
+
+/**
+ * Type override for new GPC standard (not in official DOM spec yet)
+ */
+export type NavigatorWithGPC = Navigator & {
+  /** see https://globalprivacycontrol.github.io/gpc-spec/ */
+  globalPrivacyControl: boolean;
+};


### PR DESCRIPTION
## Background:

- Customers want a way to change the privacy options available off of our default settings
- e.g. california should get GDPR + CPRA settings
- e.g. unknown should get GDPR settings

## Issue:

Previously, our UI depended on both view state and regime, this PR takes a step towards making the UI only depend on view state, and making regime independent. Eventually, we may replace regime entirely and let customers fully customize the opt out view state and purposes in a given region..


## Changes:

### Regime = GDPR

| ViewState | Before | After |
| - | - | - |
| QuickOptions | ![GDPR_QuickOptions](https://user-images.githubusercontent.com/10264973/187822454-77b88df4-6d7c-436d-bb02-5053590e11b9.jpg) |  ![AFTER_GDPR_QuickOptions](https://user-images.githubusercontent.com/10264973/187822568-60dc603a-4b26-4551-8cd9-9bcd0025c2eb.jpg) |
| AcceptAll | ![GDPR_AcceptAll](https://user-images.githubusercontent.com/10264973/187822456-2fd1ef76-498a-4441-b1b2-540a261ff849.jpg) |  ![AFTER_GDPR_AcceptAll](https://user-images.githubusercontent.com/10264973/187822545-6b04a9b3-6a3f-490a-bfcb-a3e2e06b0420.jpg) |
| DoNotSellNotice | ![GDPR_DoNotSellNotice](https://user-images.githubusercontent.com/10264973/187822457-56755416-7ca9-445f-b456-64e6e8b71fd4.jpg) | ![AFTER_GDPR_DoNotSell](https://user-images.githubusercontent.com/10264973/187822549-3d84f280-c582-4f69-b214-45dbdf19eeb9.jpg) |
| CompleteChoices | ![GDPR_CompleteChoices](https://user-images.githubusercontent.com/10264973/187822461-b0557743-60a7-4789-b79f-f501cd2da07f.jpg) | ![AFTER_GDPR_CompleteOptions](https://user-images.githubusercontent.com/10264973/187822551-4a1a1d8b-a82f-4159-9672-5faa55296cca.jpg) |

### Regime = CPRA

| ViewState | Before | After |
| - | - | - |
| QuickOptions | ![CPRA_QuickOptions](https://user-images.githubusercontent.com/10264973/187822567-a90f8946-23d0-4368-9ab1-97b571319f67.jpg) |  ![AFTER_CCPA_QuickOptions](https://user-images.githubusercontent.com/10264973/187822558-3427f795-764d-456b-b97c-6d5c75cb4627.jpg) |
| AcceptAll | ![CPRA_AcceptAll](https://user-images.githubusercontent.com/10264973/187822569-3b9821f2-55c9-4b95-b29c-a16fb12e5c6b.jpg) |  ![AFTER_CCPA_AcceptAll](https://user-images.githubusercontent.com/10264973/187822553-e726d651-bd2c-4e0e-867e-6d16272d39b4.jpg) |
| DoNotSellNotice | ![CCPA_DoNotSellNotice](https://user-images.githubusercontent.com/10264973/187822561-4080d5fc-e42a-4b2f-ac9f-09cc30893514.jpg) | ![AFTER_CCPA_DoNotSell](https://user-images.githubusercontent.com/10264973/187822565-388423af-e3c9-43f9-8e8f-b476b4bf02a4.jpg)  |
| CompleteChoices | ![CCPRA_CompleteChoices](https://user-images.githubusercontent.com/10264973/187822562-f4d0cf58-e256-49bc-ac66-f88a1aac1329.jpg) | ![AFTER_CCPA_CompleteOptions](https://user-images.githubusercontent.com/10264973/187822566-93cea06c-e3f9-4359-9d28-9febd1f7de89.jpg) |














