### PR TITLE
Allows for showConsentManager view state to be respected as simpler choice option

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "main": "src/index",
   "files": [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,10 +58,11 @@ export default function App({
   const { initialViewStateByPrivacyRegime, dismissedViewState } = config;
   const initialViewState: ViewState =
     initialViewStateByPrivacyRegime[privacyRegime];
-  const { viewState, handleSetViewState, auth } = useViewState({
-    initialViewState,
-    dismissedViewState,
-  });
+  const { viewState, firstSelectedViewState, handleSetViewState, auth } =
+    useViewState({
+      initialViewState,
+      dismissedViewState,
+    });
 
   // Event listener for the API
   appContainer.addEventListener(apiEventName, (event) => {
@@ -86,7 +87,8 @@ export default function App({
           options.viewState || ViewState.DoNotSellDisclosure,
           auth,
         ),
-      showConsentManager: () => handleSetViewState(options.viewState || 'open'),
+      showConsentManager: () =>
+        handleSetViewState(options.viewState || 'open', undefined, true),
       hideConsentManager: () => handleSetViewState('close'),
       toggleConsentManager: () =>
         handleSetViewState(viewStateIsClosed(viewState) ? 'open' : 'close'),
@@ -147,6 +149,7 @@ export default function App({
             <Main
               modalOpenAuth={auth}
               viewState={viewState}
+              firstSelectedViewState={firstSelectedViewState}
               handleSetViewState={handleSetViewState}
               handleChangeLanguage={handleChangeLanguage}
             />

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -19,7 +19,10 @@ import MenuItem from './MenuItem';
 export default function BottomMenu({
   viewState,
   handleSetViewState,
+  firstSelectedViewState,
 }: {
+  /** The first view state when opening the modal */
+  firstSelectedViewState: ViewState | null;
   /** The current viewState */
   viewState: ViewState;
   /** Function to change viewState */
@@ -62,7 +65,14 @@ export default function BottomMenu({
                 bottomMenuMessages.simplerChoicesButtonLabel,
               )}
               type="button"
-              onClick={() => handleSetViewState(ViewState.QuickOptions)}
+              onClick={() =>
+                handleSetViewState(
+                  !!firstSelectedViewState &&
+                    firstSelectedViewState !== ViewState.CompleteOptions
+                    ? firstSelectedViewState
+                    : ViewState.QuickOptions,
+                )
+              }
             >
               {formatMessage(bottomMenuMessages.simplerChoicesButtonPrimary)}
             </MenuItem>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -28,6 +28,7 @@ import DoNotSellDisclosure from './DoNotSellDisclosure';
  */
 export default function Main({
   viewState,
+  firstSelectedViewState,
   handleSetViewState,
   handleChangeLanguage,
   modalOpenAuth,
@@ -36,6 +37,8 @@ export default function Main({
   modalOpenAuth?: AirgapAuth;
   /** The current viewState of the consent manager */
   viewState: ViewState;
+  /** First view state selected when transcend.showConsentManager() is called */
+  firstSelectedViewState: ViewState | null;
   /** Updater function for viewState */
   handleSetViewState: HandleSetViewState;
   /** Updater function for language change */
@@ -92,6 +95,7 @@ export default function Main({
         <div className={cx(bottomMenuStyle)}>
           <FullLogo />
           <BottomMenu
+            firstSelectedViewState={firstSelectedViewState}
             viewState={viewState}
             handleSetViewState={handleSetViewState}
           />

--- a/src/hooks/useViewState.ts
+++ b/src/hooks/useViewState.ts
@@ -11,7 +11,7 @@ import {
 
 // global
 import { logger } from '../logger';
-import type { HandleSetViewState, RequestedViewState } from '../types';
+import type { HandleSetViewState } from '../types';
 
 /**
  * Helper to determine whether a view state is closed
@@ -47,6 +47,8 @@ export function useViewState({
   viewState: ViewState;
   /** A handler for the view state */
   handleSetViewState: HandleSetViewState;
+  /** The first view state when opening the modal */
+  firstSelectedViewState: ViewState | null;
   /** Airgap auth */
   auth?: AirgapAuth;
 } {
@@ -55,11 +57,14 @@ export function useViewState({
     current: ViewState;
     /** The previous view state - used for going back */
     previous: ViewState | null;
+    /** The first view state when opening the modal */
+    firstSelectedViewState: ViewState | null;
     /** Airgap auth */
     auth?: AirgapAuth;
   }>({
     current: ViewState.Hidden,
     previous: null,
+    firstSelectedViewState: null,
   });
 
   /**
@@ -68,7 +73,7 @@ export function useViewState({
    * @param requestedViewState - the requested next view state, 'open', 'close', or 'back'
    */
   const handleSetViewState: HandleSetViewState = useCallback(
-    (requestedViewState: RequestedViewState, auth?: AirgapAuth) => {
+    (requestedViewState, auth, resetFirstSelectedViewState = false) => {
       switch (requestedViewState) {
         // Request to go back to the previous page
         case 'back':
@@ -77,6 +82,7 @@ export function useViewState({
               current: state.previous,
               previous: state.current,
               auth,
+              firstSelectedViewState: state.firstSelectedViewState,
             });
           } else {
             logger.warn('Tried to go back when there is no previous state');
@@ -89,6 +95,7 @@ export function useViewState({
             current: initialViewState,
             previous: state.current,
             auth,
+            firstSelectedViewState: state.firstSelectedViewState,
           });
           break;
 
@@ -98,6 +105,7 @@ export function useViewState({
             current: dismissedViewState,
             previous: state.current,
             auth,
+            firstSelectedViewState: null,
           });
           break;
 
@@ -107,6 +115,9 @@ export function useViewState({
             current: requestedViewState,
             previous: state.current,
             auth,
+            firstSelectedViewState: resetFirstSelectedViewState
+              ? requestedViewState
+              : state.firstSelectedViewState || requestedViewState,
           });
           break;
       }
@@ -118,5 +129,6 @@ export function useViewState({
     viewState: state.current,
     handleSetViewState,
     auth: state.auth,
+    firstSelectedViewState: state.firstSelectedViewState,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type RequestedViewState = ViewState | 'back' | 'open' | 'close';
 export type HandleSetViewState = (
   requestedViewState: RequestedViewState,
   auth?: AirgapAuth,
+  resetFirstSelectedViewState?: boolean,
 ) => void;
 
 /**


### PR DESCRIPTION


https://user-images.githubusercontent.com/10264973/189465746-68cf6dc5-e453-46bf-96ee-21dc690af36a.mov


Before this, clicking "simple choices" always when to the `QuickOptions` UI. The customer request here is to return back to the standard experience.