### PR TITLE
Use :host selector to select shadow root in CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/cm.css
+++ b/src/cm.css
@@ -3,7 +3,7 @@
  *******************/
 
 /** Variables to insert */
-* {
+:host {
   --primary-color: #3333ff;
   --text-color: #010101;
 }


### PR DESCRIPTION
The [:host selector](https://drafts.csswg.org/css-scoping/#host-selector) targets our shadow root and is more efficient than using `*`. I have tested this cross-browser in Firefox and Chrome.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
