### PR TITLE
Allow for (non-leading/trailing) whitespace in regime names

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/regimes.ts
+++ b/src/regimes.ts
@@ -1,13 +1,10 @@
 import { PrivacyRegime } from '@transcend-io/airgap.js-types';
 import { settings } from './settings';
-import { COMMA_AND_OR_SPACE_SEPARATED_LIST } from './utils/comma-and-or-space-separated-list';
 
-const { regimePrecedence = 'GDPR LGPD CPRA CDPA CPA Unknown' } = settings;
+const { regimePrecedence = 'GDPR;LGPD;CPRA;CDPA;CPA;Unknown' } = settings;
 
 // Making this an Object rather than an Array is a TypeScript hack to ensure we have all PrivacyRegimes included
-const orderedRegimes: PrivacyRegime[] = regimePrecedence.split(
-  COMMA_AND_OR_SPACE_SEPARATED_LIST,
-);
+const orderedRegimes: PrivacyRegime[] = regimePrecedence.split(/\s*;\s*/);
 
 /**
  * Returns the PrivacyRegime with the highest precedence


### PR DESCRIPTION
We aren't emitting this from the backend yet, so it's still safe to change the input format.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
