### PR TITLE
Removes simple choices when opening directly to CompleteOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/BottomMenu.tsx
+++ b/src/components/BottomMenu.tsx
@@ -30,26 +30,24 @@ export function BottomMenu({
         ViewState.NoticeAndDoNotSell,
         ViewState.DoNotSellDisclosure,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ].includes(viewState as any) && (
-        <div className="bottom-menu-item-container">
-          {viewState === ViewState.CompleteOptions ? (
-            <MenuItem
-              label={formatMessage(
-                bottomMenuMessages.simplerChoicesButtonLabel,
-              )}
-              type="button"
-              onClick={() =>
-                handleSetViewState(
-                  !!firstSelectedViewState &&
-                    firstSelectedViewState !== ViewState.CompleteOptions
-                    ? firstSelectedViewState
-                    : ViewState.QuickOptions,
-                )
-              }
-            >
-              {formatMessage(bottomMenuMessages.simplerChoicesButtonPrimary)}
-            </MenuItem>
-          ) : (
+      ].includes(viewState as any) &&
+        (viewState === ViewState.CompleteOptions ? (
+          !firstSelectedViewState ||
+          firstSelectedViewState === ViewState.CompleteOptions ? null : (
+            <div className="bottom-menu-item-container">
+              <MenuItem
+                label={formatMessage(
+                  bottomMenuMessages.simplerChoicesButtonLabel,
+                )}
+                type="button"
+                onClick={() => handleSetViewState(firstSelectedViewState)}
+              >
+                {formatMessage(bottomMenuMessages.simplerChoicesButtonPrimary)}
+              </MenuItem>
+            </div>
+          )
+        ) : (
+          <div className="bottom-menu-item-container">
             <MenuItem
               label={formatMessage(bottomMenuMessages.moreChoicesButtonLabel)}
               type="button"
@@ -57,9 +55,8 @@ export function BottomMenu({
             >
               {formatMessage(bottomMenuMessages.moreChoicesButtonPrimary)}
             </MenuItem>
-          )}
-        </div>
-      )}
+          </div>
+        ))}
 
       {viewState === ViewState.NoticeAndDoNotSell && (
         <div className="bottom-menu-item-container">


### PR DESCRIPTION
- links https://transcend.height.app/T-19406

When calling `transcend.showConsentManager({ viewState: 'CompleteOptions' })`, we now hide the option to view "simple choices". 

Normally when customers open up directly to `CompleteOptions`, they are doing it because they want to use that UI experience in isolation, not swapping between simpler options and checkbox options.

https://user-images.githubusercontent.com/10264973/200449766-2447f56a-b6dc-440b-a27a-a461fdbc2402.mov
