### PR TITLE
Use `Hidden` view state by default for `dismissedViewState`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -96,7 +96,11 @@ export function Main({
   }
 
   // Modal collapsed view
-  if (viewState === ViewState.Collapsed) {
+  if (
+    viewState === ViewState.Collapsed &&
+    firstSelectedViewState &&
+    !viewStateIsClosed(firstSelectedViewState)
+  ) {
     return <Collapsed handleSetViewState={handleSetViewState} />;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ import { jsonParseSafe } from './utils/safe-json-parse';
 const {
   privacyCenter,
   privacyPolicy = privacyCenter || '/privacy',
-  dismissedViewState = ViewState.Collapsed,
+  dismissedViewState = ViewState.Hidden,
 } = settings;
 
 // Base configuration


### PR DESCRIPTION
This PR also prevents the persistent floating widget from rendering if the initial view state is 'closed'

## Related Issues

- Closes https://transcend.height.app/T-19986
- Closes https://transcend.height.app/T-19987

## Security Implications

_[none]_

## System Availability

_[none]_
