### PR TITLE
Fix inverted logic in `Collapsed` view

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -98,8 +98,7 @@ export function Main({
   // Modal collapsed view
   if (
     viewState === ViewState.Collapsed &&
-    firstSelectedViewState &&
-    !viewStateIsClosed(firstSelectedViewState)
+    (!firstSelectedViewState || !viewStateIsClosed(firstSelectedViewState))
   ) {
     return <Collapsed handleSetViewState={handleSetViewState} />;
   }


### PR DESCRIPTION
Prior to this PR, `dismissedViewState: 'Collapsed'` was being ignored due to an inverted logic check from #81

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
