### PR TITLE
Removes copied view state

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -48,7 +48,7 @@ export const build = async (
         plugins: [
           alias({
             react: require.resolve('preact/compat'),
-            tslib: require.resolve('tslib/tslib.es6'),
+            tslib: require.resolve('tslib/tslib.es6.js'),
             'react-dom/test-utils': require.resolve('preact/test-utils'),
             'react-dom': require.resolve('preact/compat'),
             'react/jsx-runtime': require.resolve('preact/jsx-runtime'),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@
 import type {
   ConsentManagerConfig,
   ConsentManagerConfigInput,
-  ViewState,
   PrivacyRegimeToInitialViewState,
 } from '@transcend-io/airgap.js-types';
+import { ViewState } from '@transcend-io/airgap.js-types/build/enums/viewState';
 import { logger } from './logger';
 import { settings, LOG_LEVELS, extraConfig } from './settings';
 import { jsonParseSafe } from './utils/safe-json-parse';
@@ -60,31 +60,6 @@ const baseConfig: Omit<
   },
   initialViewStateByPrivacyRegime: DEFAULT_VIEW_STATE_BY_PRIVACY_REGIME_COPIED,
 };
-
-/**
- * This enum is copied to avoid airgap.js-types
- * being a production dependency for this package.
- * TODO: https://transcend.height.app/T-20982 - consider
- * a simpler option, such as a dedicated package for constants
- */
-export const CopiedViewStates: { [k in ViewState]: ViewState } = {
-  Collapsed: 'Collapsed',
-  Closed: 'Closed',
-  LanguageOptions: 'LanguageOptions',
-  QuickOptions: 'QuickOptions',
-  QuickOptions3: 'QuickOptions3',
-  AcceptAll: 'AcceptAll',
-  AcceptOrRejectAll: 'AcceptOrRejectAll',
-  AcceptOrRejectAnalytics: 'AcceptOrRejectAnalytics',
-  NoticeAndDoNotSell: 'NoticeAndDoNotSell',
-  DoNotSellExplainer: 'DoNotSellExplainer',
-  DoNotSellDisclosure: 'DoNotSellDisclosure',
-  PrivacyPolicyNotice: 'PrivacyPolicyNotice',
-  CompleteOptions: 'CompleteOptions',
-  CompleteOptionsInverted: 'CompleteOptionsInverted',
-  Hidden: 'Hidden',
-};
-
 /**
  * Merges config from defaults and settings. JSON is automatically decoded.
  *
@@ -136,7 +111,7 @@ const validateViewState = (
   param: string,
   errors: string[],
 ): boolean => {
-  const valid = Object.values(CopiedViewStates).some(
+  const valid = Object.values(ViewState).some(
     (knownViewState) => knownViewState === viewState,
   );
   if (!valid) {

--- a/src/consent-manager.tsx
+++ b/src/consent-manager.tsx
@@ -9,7 +9,7 @@ import { logger } from './logger';
 import { apiEventName } from './settings';
 import { createHTMLElement } from './utils/create-html-element';
 import { EmitEventOptions } from './types';
-import { CopiedViewStates } from './config';
+import { ViewState } from '@transcend-io/airgap.js-types/build/enums/viewState';
 
 let interfaceInitialized = false;
 
@@ -75,7 +75,7 @@ export const injectConsentManagerApp = (
             eventType: 'setActiveLocale',
             locale,
           }),
-        viewStates: new Set(Object.values(CopiedViewStates)),
+        viewStates: new Set(Object.values(ViewState)),
         doNotSell: (auth, options: ShowConsentManagerOptions = {}) =>
           dispatchConsentManagerAPIEvent(appContainer, {
             eventType: 'doNotSell',

--- a/src/playground/Main.tsx
+++ b/src/playground/Main.tsx
@@ -1,5 +1,4 @@
-import { CopiedViewStates } from '../config';
-import type { ViewState } from '@transcend-io/airgap.js-types';
+import { ViewState } from '@transcend-io/airgap.js-types/build/enums/viewState';
 import { h, JSX } from 'preact';
 import { Config } from './Config';
 import { ConsentLog } from './ConsentLog';
@@ -27,7 +26,7 @@ export default function Main(): JSX.Element {
         <p style={{ fontWeight: '600', fontSize: '12px', margin: '0 0 3px 0' }}>
           Open a view
         </p>
-        {Object.values(CopiedViewStates)
+        {Object.values(ViewState)
           .filter((viewState) => viewState !== 'DoNotSellDisclosure')
           .map((viewState) => (
             <button


### PR DESCRIPTION
- closes https://transcend.height.app/T-20989
- closes https://transcend.height.app/T-20983
- closes https://transcend.height.app/T-20986
- closes https://transcend.height.app/T-20984
- closes https://transcend.height.app/T-20983

this diff changes bundle size from 211kb to 269kb: https://github.com/transcend-io/consent-manager-ui/pull/105/files
its a little more than id like, but i think its still small enough where id vote to just import this from airgap.js-types for now instead of building another package just for constants. our customers import these type packages into their code, so having a simple process is beneficial.

i used chrome overrides to test that this change does not re-introduce the import star error.