### PR TITLE
Fix alt text on consent manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/cm.css
+++ b/src/cm.css
@@ -699,8 +699,7 @@ a:focus-visible {
 }
 
 /** Scrollbar border */
-.scroller::-webkit-scrollbar,
-.scroller::-webkit-scrollbar-thumb,
+.scroller::-webkit-scrollbar, .scroller::-webkit-scrollbar-thumb,
 .scroller::-webkit-scrollbar-corner {
   border-color: inherit;
   border-right-width: calc(100vw + 100vh);

--- a/src/components/CompleteOptionsInverted.tsx
+++ b/src/components/CompleteOptionsInverted.tsx
@@ -89,6 +89,7 @@ export function CompleteOptionsInverted({
           {orderedSelections.map(([purpose, isChecked]) => (
             <Toggle
               key={purpose}
+              invertLabels
               name={
                 Object.hasOwnProperty.call(purposeToMessageKey, purpose)
                   ? formatMessage(purposeToMessageKey[purpose])

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -12,6 +12,7 @@ export function Toggle({
   disabled,
   handleToggle,
   ariaLabel,
+  invertLabels,
 }: {
   /** The name for this consent toggle */
   name: string;
@@ -23,6 +24,8 @@ export function Toggle({
   handleToggle: (checked: boolean) => void;
   /** An override to the default aria label */
   ariaLabel?: string;
+  /** When true, invert the labels for the alt text */
+  invertLabels?: boolean;
 }): JSX.Element {
   const { formatMessage } = useIntl();
 
@@ -36,6 +39,7 @@ export function Toggle({
 
   const id = name.replace(/\s/g, '-').toLowerCase();
 
+  const useToggleDisable = invertLabels ? !toggleState : !!toggleState;
   return (
     <label
       className="toggle-label"
@@ -43,7 +47,7 @@ export function Toggle({
       aria-label={
         ariaLabel ||
         `${
-          toggleState
+          useToggleDisable
             ? formatMessage(completeOptionsMessages.toggleDisable)
             : formatMessage(completeOptionsMessages.toggleEnable)
         } – ${name.toLocaleLowerCase()}`
@@ -51,7 +55,7 @@ export function Toggle({
       title={
         ariaLabel ||
         `${
-          toggleState
+          useToggleDisable
             ? formatMessage(completeOptionsMessages.toggleDisable)
             : formatMessage(completeOptionsMessages.toggleEnable)
         } – ${name.toLocaleLowerCase()}`


### PR DESCRIPTION
Alt/hover labels were inverted for this banner type

![Screen Shot 2023-01-05 at 5 05 39 PM](https://user-images.githubusercontent.com/10264973/210908966-8030f2af-4961-4941-b5b1-042f39461370.jpg)
