### PR TITLE
Playground: fix bug on initial load w/o localStorage set

### DIFF
--- a/src/playground/airgapStub.ts
+++ b/src/playground/airgapStub.ts
@@ -4,13 +4,14 @@
 /* eslint-disable jsdoc/require-returns */
 
 import type { AirgapAPI } from '@transcend-io/airgap.js-types';
+import { defaultTrackingPurposes } from './defaults';
 import { getPrivacySignalsFromLocalStorage } from './Environment';
 import { appendConsentLog } from './helpers/consentLog';
 
 const getPurposeTypes: AirgapAPI['getPurposeTypes'] = () => {
   const purposeTypes = localStorage.getItem('getPurposeTypes');
   if (!purposeTypes) {
-    throw new Error('Missing purpose types!');
+    return defaultTrackingPurposes;
   }
   return JSON.parse(purposeTypes);
 };


### PR DESCRIPTION
On initial load of the playground, there was an incorrect assumption that an item was in localStorage.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
