### PR TITLE
Ability to add description text to CompleteOptions ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ This option is linked to in most other banners under the "More Choices" footer. 
 
 ![ViewState = CompleteOptions](https://user-images.githubusercontent.com/10264973/188251095-7c7fd1b5-7748-4430-b7af-130e37db2dc5.jpg)
 
+With optional description text:
+
+![ViewState = CompleteOptions with description](https://user-images.githubusercontent.com/10264973/231072703-7cc9e7c7-a02e-4598-ad08-b5dc6d029165.png)
+
 #### Button Mapping
 
 | Button Title           | Callback Description                                                                                                                                                                                                                                                                                             |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/CompleteOptions.tsx
+++ b/src/components/CompleteOptions.tsx
@@ -76,6 +76,9 @@ export function CompleteOptions({
         ORDER_OF_PURPOSES.indexOf(a) - ORDER_OF_PURPOSES.indexOf(b),
   );
 
+  // Render description
+  const description = formatMessage(completeOptionsMessages.description);
+
   return (
     <div className="complete-options-container">
       <p className="text-title text-title-center">
@@ -83,6 +86,17 @@ export function CompleteOptions({
       </p>
       <form className="complete-options-form">
         <GPCIndicator />
+        {description && description !== '-' ? (
+          <p className="paragraph">
+            <div
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: description,
+              }}
+            />
+          </p>
+        ) : undefined}
+
         <div className="toggles-container">
           <Toggle
             key="Essential"

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -325,6 +325,11 @@ export const completeOptionsMessages = defineMessages(
       description:
         'Text to display when Global Privacy Control (GPC) is respected.',
     },
+    description: {
+      defaultMessage: '-',
+      description:
+        'Freeform description text for the CompleteOptions consent banner.',
+    },
   },
 );
 

--- a/src/translations/af-ZA.json
+++ b/src/translations/af-ZA.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Eenvoudiger keuses",
   "ui.src.completeOptions.advertisingLabel": "Advertising",
   "ui.src.completeOptions.analyticsLabel": "analise",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Essensiële data-insameling kan nie afgeskakel word nie.",
   "ui.src.completeOptions.essentialLabel": "Essensiële doeleindes",
   "ui.src.completeOptions.functionalLabel": "Funksionaliteit",

--- a/src/translations/ar-AE.json
+++ b/src/translations/ar-AE.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "اختيارات أبسط",
   "ui.src.completeOptions.advertisingLabel": "الإعلان",
   "ui.src.completeOptions.analyticsLabel": "تحليلات",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "لا يمكن إيقاف تشغيل جمع البيانات الأساسية.",
   "ui.src.completeOptions.essentialLabel": "أغراض أساسية",
   "ui.src.completeOptions.functionalLabel": "الوظائف",

--- a/src/translations/bg-BG.json
+++ b/src/translations/bg-BG.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "По-опростен избор",
   "ui.src.completeOptions.advertisingLabel": "Реклама",
   "ui.src.completeOptions.analyticsLabel": "Анализ",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Събирането на съществени данни не може да бъде изключено.",
   "ui.src.completeOptions.essentialLabel": "Основни цели",
   "ui.src.completeOptions.functionalLabel": "Функционалност",

--- a/src/translations/cs-CZ.json
+++ b/src/translations/cs-CZ.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Jednodušší volby",
   "ui.src.completeOptions.advertisingLabel": "Reklamní",
   "ui.src.completeOptions.analyticsLabel": "Analytika",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Základní sběr dat nelze vypnout.",
   "ui.src.completeOptions.essentialLabel": "Základní účely",
   "ui.src.completeOptions.functionalLabel": "Funkčnost",

--- a/src/translations/da-DK.json
+++ b/src/translations/da-DK.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Enklere valg",
   "ui.src.completeOptions.advertisingLabel": "Annoncering",
   "ui.src.completeOptions.analyticsLabel": "Analyse-værktøj",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Vigtig dataindsamling kan ikke slås fra.",
   "ui.src.completeOptions.essentialLabel": "Væsentlige formål",
   "ui.src.completeOptions.functionalLabel": "funktionalitet",

--- a/src/translations/de-DE.json
+++ b/src/translations/de-DE.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Einfachere Auswahlmöglichkeiten",
   "ui.src.completeOptions.advertisingLabel": "Werbung",
   "ui.src.completeOptions.analyticsLabel": "Analytics",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Die Erfassung wichtiger Daten kann nicht deaktiviert werden.",
   "ui.src.completeOptions.essentialLabel": "Essentielle Zwecke",
   "ui.src.completeOptions.functionalLabel": "Funktionalität",

--- a/src/translations/description.json
+++ b/src/translations/description.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Text for selecting simpler opt out choices.",
   "ui.src.completeOptions.advertisingLabel": "Text for advertising purposes in CompleteOptions view state.",
   "ui.src.completeOptions.analyticsLabel": "Text for analytics purposes in CompleteOptions view state.",
+  "ui.src.completeOptions.description": "Freeform description text for the CompleteOptions consent banner.",
   "ui.src.completeOptions.essentialAriaLabel": "Hover/alt text for disabled essential purposes in CompleteOptions view state.",
   "ui.src.completeOptions.essentialLabel": "Text for essential purposes in CompleteOptions view state.",
   "ui.src.completeOptions.functionalLabel": "Text for functional purposes in CompleteOptions view state.",

--- a/src/translations/el-GR.json
+++ b/src/translations/el-GR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Απλότερες επιλογές",
   "ui.src.completeOptions.advertisingLabel": "Διαφήμιση",
   "ui.src.completeOptions.analyticsLabel": "Analytics",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Η συλλογή βασικών δεδομένων δεν μπορεί να απενεργοποιηθεί.",
   "ui.src.completeOptions.essentialLabel": "Βασικοί σκοποί",
   "ui.src.completeOptions.functionalLabel": "Λειτουργικότητα",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Simpler choices",
   "ui.src.completeOptions.advertisingLabel": "Advertising",
   "ui.src.completeOptions.analyticsLabel": "Analytics",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Essential data collection cannot be turned off.",
   "ui.src.completeOptions.essentialLabel": "Essential purposes",
   "ui.src.completeOptions.functionalLabel": "Functionality",

--- a/src/translations/es-419.json
+++ b/src/translations/es-419.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Opciones más simples",
   "ui.src.completeOptions.advertisingLabel": "Publicidad",
   "ui.src.completeOptions.analyticsLabel": "Analítica",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "La recopilación de datos esenciales no se puede desactivar.",
   "ui.src.completeOptions.essentialLabel": "Fines esenciales",
   "ui.src.completeOptions.functionalLabel": "Funcionalidad",

--- a/src/translations/es-ES.json
+++ b/src/translations/es-ES.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Opciones más sencillas",
   "ui.src.completeOptions.advertisingLabel": "Publicidad",
   "ui.src.completeOptions.analyticsLabel": "Analítica",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "La recopilación de datos esenciales no se puede desactivar.",
   "ui.src.completeOptions.essentialLabel": "Propósitos esenciales",
   "ui.src.completeOptions.functionalLabel": "Funcionalidad",

--- a/src/translations/fi-FI.json
+++ b/src/translations/fi-FI.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Yksinkertaisempia valintoja",
   "ui.src.completeOptions.advertisingLabel": "Mainonta",
   "ui.src.completeOptions.analyticsLabel": "Analytiikka",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Oleellista tiedonkeruuta ei voi poistaa käytöstä.",
   "ui.src.completeOptions.essentialLabel": "Olennaiset tavoitteet",
   "ui.src.completeOptions.functionalLabel": "toiminnallisuus",

--- a/src/translations/fr-FR.json
+++ b/src/translations/fr-FR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Des choix plus simples",
   "ui.src.completeOptions.advertisingLabel": "Publicité",
   "ui.src.completeOptions.analyticsLabel": "Analyses",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "La collecte de données essentielles ne peut pas être désactivée.",
   "ui.src.completeOptions.essentialLabel": "Objectifs essentiels",
   "ui.src.completeOptions.functionalLabel": "Fonctionnalité",

--- a/src/translations/he-IL.json
+++ b/src/translations/he-IL.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "אפשרויות פשוטות יותר",
   "ui.src.completeOptions.advertisingLabel": "פרסום",
   "ui.src.completeOptions.analyticsLabel": "ניתוח",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "לא ניתן לכבות את איסוף הנתונים החיוניים.",
   "ui.src.completeOptions.essentialLabel": "מטרות חיוניות",
   "ui.src.completeOptions.functionalLabel": "פונקציונליות",

--- a/src/translations/hi-IN.json
+++ b/src/translations/hi-IN.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "आसान विकल्प",
   "ui.src.completeOptions.advertisingLabel": "विज्ञापन",
   "ui.src.completeOptions.analyticsLabel": "एनालिटिक्स",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "आवश्यक डेटा संग्रह को बंद नहीं किया जा सकता है।",
   "ui.src.completeOptions.essentialLabel": "आवश्यक उद्देश्य",
   "ui.src.completeOptions.functionalLabel": "कार्यात्मकता",

--- a/src/translations/hr-HR.json
+++ b/src/translations/hr-HR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Jednostavniji izbori",
   "ui.src.completeOptions.advertisingLabel": "Oglašavanje",
   "ui.src.completeOptions.analyticsLabel": "Analitika",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Prikupljanje osnovnih podataka ne može se isključiti.",
   "ui.src.completeOptions.essentialLabel": "Osnovne svrhe",
   "ui.src.completeOptions.functionalLabel": "Funkcionalnost",

--- a/src/translations/hu-HU.json
+++ b/src/translations/hu-HU.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Egyszerűbb választás",
   "ui.src.completeOptions.advertisingLabel": "Reklám",
   "ui.src.completeOptions.analyticsLabel": "Analitika",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Az alapvető adatgyűjtést nem lehet kikapcsolni.",
   "ui.src.completeOptions.essentialLabel": "Alapvető célok",
   "ui.src.completeOptions.functionalLabel": "funkcionalitás",

--- a/src/translations/id-ID.json
+++ b/src/translations/id-ID.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Pilihan yang lebih sederhana",
   "ui.src.completeOptions.advertisingLabel": "Periklanan",
   "ui.src.completeOptions.analyticsLabel": "Analitik",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Pengumpulan data penting tidak dapat dimatikan.",
   "ui.src.completeOptions.essentialLabel": "Tujuan penting",
   "ui.src.completeOptions.functionalLabel": "Fungsionalitas",

--- a/src/translations/it-IT.json
+++ b/src/translations/it-IT.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Scelte più semplici",
   "ui.src.completeOptions.advertisingLabel": "Pubblicità",
   "ui.src.completeOptions.analyticsLabel": "analitica",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "La raccolta dei dati essenziali non può essere disattivata.",
   "ui.src.completeOptions.essentialLabel": "Scopi essenziali",
   "ui.src.completeOptions.functionalLabel": "Funzionalità",

--- a/src/translations/ja-JP.json
+++ b/src/translations/ja-JP.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "よりシンプルな選択肢",
   "ui.src.completeOptions.advertisingLabel": "広告",
   "ui.src.completeOptions.analyticsLabel": "分析",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "重要なデータ収集はオフにできません。",
   "ui.src.completeOptions.essentialLabel": "本質的な目的",
   "ui.src.completeOptions.functionalLabel": "機能性",

--- a/src/translations/ko-KR.json
+++ b/src/translations/ko-KR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "더 간단한 선택",
   "ui.src.completeOptions.advertisingLabel": "광고",
   "ui.src.completeOptions.analyticsLabel": "해석학",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "필수 데이터 수집은 끌 수 없습니다.",
   "ui.src.completeOptions.essentialLabel": "필수 목적",
   "ui.src.completeOptions.functionalLabel": "기능성",

--- a/src/translations/lt-LT.json
+++ b/src/translations/lt-LT.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Paprastesnis pasirinkimas",
   "ui.src.completeOptions.advertisingLabel": "Skelbimai",
   "ui.src.completeOptions.analyticsLabel": "„Analytics“",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Esminių duomenų rinkimas negali būti išjungtas.",
   "ui.src.completeOptions.essentialLabel": "Esminiai tikslai",
   "ui.src.completeOptions.functionalLabel": "funkcionalumas",

--- a/src/translations/mr-IN.json
+++ b/src/translations/mr-IN.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Simpler choices",
   "ui.src.completeOptions.advertisingLabel": "Advertising",
   "ui.src.completeOptions.analyticsLabel": "Analytics",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Essential data collection cannot be turned off.",
   "ui.src.completeOptions.essentialLabel": "Essential purposes",
   "ui.src.completeOptions.functionalLabel": "Functionality",

--- a/src/translations/ms-MY.json
+++ b/src/translations/ms-MY.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Pilihan yang lebih mudah",
   "ui.src.completeOptions.advertisingLabel": "Pengiklanan",
   "ui.src.completeOptions.analyticsLabel": "Analitik",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Pengumpulan data penting tidak boleh dimatikan.",
   "ui.src.completeOptions.essentialLabel": "Tujuan penting",
   "ui.src.completeOptions.functionalLabel": "Fungsi",

--- a/src/translations/nb-NO.json
+++ b/src/translations/nb-NO.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Enklere valg",
   "ui.src.completeOptions.advertisingLabel": "Annonsering",
   "ui.src.completeOptions.analyticsLabel": "Analyser",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Viktig datainnsamling kan ikke slås av.",
   "ui.src.completeOptions.essentialLabel": "Viktige formål",
   "ui.src.completeOptions.functionalLabel": "funksjonalitet",

--- a/src/translations/nl-NL.json
+++ b/src/translations/nl-NL.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Eenvoudigere keuzes",
   "ui.src.completeOptions.advertisingLabel": "Reclame",
   "ui.src.completeOptions.analyticsLabel": "analytici",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Essentiële gegevensverzameling kan niet worden uitgeschakeld.",
   "ui.src.completeOptions.essentialLabel": "Essentiële doeleinden",
   "ui.src.completeOptions.functionalLabel": "Functie",

--- a/src/translations/pl-PL.json
+++ b/src/translations/pl-PL.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Prostsze wybory",
   "ui.src.completeOptions.advertisingLabel": "Reklama",
   "ui.src.completeOptions.analyticsLabel": "Analizy",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Nie można wyłączyć gromadzenia podstawowych danych.",
   "ui.src.completeOptions.essentialLabel": "Niezbędne cele",
   "ui.src.completeOptions.functionalLabel": "Funkcjonalność",

--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Escolhas mais simples",
   "ui.src.completeOptions.advertisingLabel": "Publicidade",
   "ui.src.completeOptions.analyticsLabel": "Análise",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "A coleta de dados essenciais não pode ser desativada.",
   "ui.src.completeOptions.essentialLabel": "Propósitos essenciais",
   "ui.src.completeOptions.functionalLabel": "Funcionalidade",

--- a/src/translations/ro-RO.json
+++ b/src/translations/ro-RO.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Alegeri mai simple",
   "ui.src.completeOptions.advertisingLabel": "Publicitate",
   "ui.src.completeOptions.analyticsLabel": "Analiză",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Colectarea datelor esențiale nu poate fi dezactivată.",
   "ui.src.completeOptions.essentialLabel": "Scopuri esențiale",
   "ui.src.completeOptions.functionalLabel": "Funcționalitate",

--- a/src/translations/ru-RU.json
+++ b/src/translations/ru-RU.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Более простой выбор",
   "ui.src.completeOptions.advertisingLabel": "Реклама",
   "ui.src.completeOptions.analyticsLabel": "аналитика",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Сбор важных данных нельзя отключить.",
   "ui.src.completeOptions.essentialLabel": "Основные цели",
   "ui.src.completeOptions.functionalLabel": "функциональность",

--- a/src/translations/sr-Latn-RS.json
+++ b/src/translations/sr-Latn-RS.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Jednostavniji izbori",
   "ui.src.completeOptions.advertisingLabel": "Reklamiranje",
   "ui.src.completeOptions.analyticsLabel": "Analitika",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Prikupljanje osnovnih podataka ne može se isključiti.",
   "ui.src.completeOptions.essentialLabel": "Osnovne svrhe",
   "ui.src.completeOptions.functionalLabel": "Funkcionalnost",

--- a/src/translations/sv-SE.json
+++ b/src/translations/sv-SE.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Enklare val",
   "ui.src.completeOptions.advertisingLabel": "Annonsering",
   "ui.src.completeOptions.analyticsLabel": "Analyser",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Viktig datainsamling kan inte stängas av.",
   "ui.src.completeOptions.essentialLabel": "Viktiga syften",
   "ui.src.completeOptions.functionalLabel": "Funktion",

--- a/src/translations/ta-IN.json
+++ b/src/translations/ta-IN.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "எளிமையான தேர்வுகள்",
   "ui.src.completeOptions.advertisingLabel": "விளம்பரம்",
   "ui.src.completeOptions.analyticsLabel": "பகுப்பாராய்ச்சிகள்",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "அத்தியாவசிய தரவு சேகரிப்பு அணைக்க முடியாது.",
   "ui.src.completeOptions.essentialLabel": "அத்தியாவசிய நோக்கங்கள்",
   "ui.src.completeOptions.functionalLabel": "செயற்பாடுகள்",

--- a/src/translations/th-TH.json
+++ b/src/translations/th-TH.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "ตัวเลือกที่ง่ายกว่า",
   "ui.src.completeOptions.advertisingLabel": "การโฆษณา",
   "ui.src.completeOptions.analyticsLabel": "วิิเคราะห์วิทยา",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "การเก็บรวบรวมข้อมูลสำคัญไม่สามารถปิดได้",
   "ui.src.completeOptions.essentialLabel": "วัตถุประสงค์ที่สำคัญ",
   "ui.src.completeOptions.functionalLabel": "ฟังก์ชันการทำงาน",

--- a/src/translations/tr-TR.json
+++ b/src/translations/tr-TR.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Daha basit seçimler",
   "ui.src.completeOptions.advertisingLabel": "Reklam",
   "ui.src.completeOptions.analyticsLabel": "Analitik",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Temel veri toplama kapatılamaz.",
   "ui.src.completeOptions.essentialLabel": "Temel amaçlar",
   "ui.src.completeOptions.functionalLabel": "Fonksiyonellik",

--- a/src/translations/uk-UA.json
+++ b/src/translations/uk-UA.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Простіший вибір",
   "ui.src.completeOptions.advertisingLabel": "Реклама",
   "ui.src.completeOptions.analyticsLabel": "Аналітика",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Збір основних даних не може бути вимкнений.",
   "ui.src.completeOptions.essentialLabel": "Істотні цілі",
   "ui.src.completeOptions.functionalLabel": "Функціональність",

--- a/src/translations/vi-VN.json
+++ b/src/translations/vi-VN.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "Lựa chọn đơn giản hơn",
   "ui.src.completeOptions.advertisingLabel": "Quảng cáo",
   "ui.src.completeOptions.analyticsLabel": "phân tích",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "Không thể tắt thu thập dữ liệu thiết yếu.",
   "ui.src.completeOptions.essentialLabel": "Mục đích thiết yếu",
   "ui.src.completeOptions.functionalLabel": "Chức năng",

--- a/src/translations/zh-CN.json
+++ b/src/translations/zh-CN.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "更简单的选择",
   "ui.src.completeOptions.advertisingLabel": "广告",
   "ui.src.completeOptions.analyticsLabel": "分析",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "无法关闭基本数据收集。",
   "ui.src.completeOptions.essentialLabel": "基本用途",
   "ui.src.completeOptions.functionalLabel": "功能性",

--- a/src/translations/zh-HK.json
+++ b/src/translations/zh-HK.json
@@ -10,6 +10,7 @@
   "ui.src.bottomMenu.simplerChoicesButtonPrimary": "更簡單的選擇",
   "ui.src.completeOptions.advertisingLabel": "广告",
   "ui.src.completeOptions.analyticsLabel": "分析",
+  "ui.src.completeOptions.description": "-",
   "ui.src.completeOptions.essentialAriaLabel": "無法關閉基本資料收集。",
   "ui.src.completeOptions.essentialLabel": "基本目的",
   "ui.src.completeOptions.functionalLabel": "功能",


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-24003

Exposes the ability to add an HTML description to the CompleteOptions UI. Does not change the default UI state.

<img width="643" alt="Screenshot 2023-04-10 at 11 10 14 PM" src="https://user-images.githubusercontent.com/10264973/231072703-7cc9e7c7-a02e-4598-ad08-b5dc6d029165.png">
