### PR TITLE
Fix backdrop filter on Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/cm.css
+++ b/src/cm.css
@@ -504,6 +504,7 @@ a:focus {
     helvetica neue, helvetica, 'sans-serif';
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(20px) saturate(5);
+  -webkit-backdrop-filter: blur(20px) saturate(5);
   animation: fadeIn 150ms;
   max-height: 90%;
   transition: width 150ms, height 150ms;


### PR DESCRIPTION
Fixes a bug where `backdrop-filter` was not rendering in Safari, causing background content to appear through the Consent Manager UI.

### CHROME (NOMINAL)
<img width="1385" alt="Screenshot 2023-08-29 at 11 09 37 AM" src="https://github.com/transcend-io/consent-manager-ui/assets/7354176/af91048e-13df-4d4c-97ea-f002a6422b70">


### SAFARI (BUG)
<img width="1388" alt="Screenshot 2023-08-29 at 11 09 35 AM" src="https://github.com/transcend-io/consent-manager-ui/assets/7354176/9b589e29-87f9-4b41-8e5b-6b916a869547">

## Related Issues

- Closes T-28507 [Consent Manager UI] Safari does not render back-drop filter

## Security Implications

_[none]_

## System Availability

_[none]_
