### PR TITLE
check airgap prompted state

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -73,7 +73,7 @@ export function Main({
 
   // Modal open views
   if (!isViewStateClosed(viewState)) {
-    if (!isResponseViewState(viewState)) {
+    if (!isResponseViewState(viewState) && !airgap.getConsent().prompted) {
       airgap.setPrompted(true);
     }
     return (


### PR DESCRIPTION
## Internal Changelog

airgap.setPrompted can change the consentCacheTimestamp value and also initiate an unnecessary xdi/preference store sync, so we should only call it unless we really have to (i.e., if we haven't already prompted). This also creates a bug specifically if the user is both 1) forcing the ui to display when already prompted and 2) using preference store to sync across browsers/devices. Luckily that combination should be extremely rare (I think none of our customers currently fall into that bucket?), but it's much more prevalent when debugging preference store logic since part of the dev loop will likely involve forcing ui visibility.