### PR TITLE
reset active element/focus order state on ui close

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -58,6 +58,11 @@ export function App({
       initialViewState,
       dismissedViewState,
       eventTarget,
+      savedActiveElement:
+        document.activeElement instanceof HTMLElement &&
+        document.activeElement !== document.body
+          ? document.activeElement
+          : null,
     });
 
   // Language setup

--- a/src/hooks/useViewState.ts
+++ b/src/hooks/useViewState.ts
@@ -128,6 +128,12 @@ export function useViewState({
             auth,
             firstSelectedViewState: null,
           });
+          /* If the user previously had something focused before the modal popped up, then focus it.
+           * Otherwise, we have to do this really janky "reset" behavior with the temporary element
+           * because Chrome specifically has some weird internal state around focus order that is
+           * very difficult to interact with. We create an element with maximum focus priority and
+           * focus it so that when we delete it the user will be at the start of the focus order
+           * just like if they had freshly loaded the page. */
           if (savedActiveElement !== null) {
             savedActiveElement.focus();
           } else {

--- a/src/hooks/useViewState.ts
+++ b/src/hooks/useViewState.ts
@@ -52,6 +52,7 @@ export function useViewState({
   initialViewState,
   dismissedViewState,
   eventTarget,
+  savedActiveElement,
 }: {
   /** Which state this consent manager should go to when opened */
   initialViewState: InitialViewState;
@@ -59,6 +60,8 @@ export function useViewState({
   dismissedViewState: DismissedViewState;
   /** The event target on the `transcend` API, where we will dispatch view state change events */
   eventTarget: EventTarget;
+  /** Element previously focused before our ui modal was opened */
+  savedActiveElement: HTMLElement | null;
 }): {
   /** The current view state */
   viewState: ViewState;
@@ -118,14 +121,24 @@ export function useViewState({
           break;
 
         // Request to close the modal, to the closed view state (which depends on whether customer wants to display the collapse view or hide it)
-        case 'close':
+        case 'close': {
           setState({
             current: dismissedViewState,
             previous: state.current,
             auth,
             firstSelectedViewState: null,
           });
+          if (savedActiveElement !== null) {
+            savedActiveElement.focus();
+          } else {
+            const tempInteractiveEl = document.createElement('span');
+            tempInteractiveEl.setAttribute('tabindex', '1');
+            document.body.prepend(tempInteractiveEl);
+            tempInteractiveEl.focus();
+            tempInteractiveEl.remove();
+          }
           break;
+        }
 
         // Request to go to a specific view state, e.g. the language options page
         default:


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-31732

## Changelog

This solves a really weird (browser specific) accessibility bug, wherein Chrome users relying on tab focus order for navigation would be routed to the URL bar after modal closure instead of the first interactive/tabindexed element on the page. Various solutions were attempted, such as focusing the document body and blurring the activeElement, but there appeared to be hidden focus order state that wasn't being reset upon a simple element `focus` call. The only solution I found to work was creating a dummy interactive element with maximum focus priority (i.e. tabindex of 1, at the very start of the body), then focusing and removing it. This essentially puts the focus order pointer at the very start of the list so the next tab will focus the first interactive element just as it would on a fresh page load.