### PR TITLE
await css injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.13.3",
+  "version": "4.13.4",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/css.ts
+++ b/src/css.ts
@@ -17,7 +17,7 @@ export const injectCss = (stylesheetUrl: string): Promise<void> =>
       link.rel = 'stylesheet';
       link.id = stylesheetUrl;
       link.href = stylesheetUrl;
-      link.addEventListener('load', () => res);
+      link.addEventListener('load', () => res());
       root.appendChild(link);
     } else {
       logger.error(`Failed to inject css into consent manager!`);

--- a/src/css.ts
+++ b/src/css.ts
@@ -6,17 +6,20 @@ import { createHTMLElement } from './utils/create-html-element';
  * Inject CSS into the application
  *
  * @param stylesheetUrl - The default URL to attempt to load CSS rom
+ * @returns Promise that finishes when the stylesheet has loaded
  */
-export const injectCss = (stylesheetUrl: string): void => {
-  const root = getAppContainer();
-  if (root && stylesheetUrl) {
-    const link = createHTMLElement<HTMLLinkElement>('link');
-    link.type = 'text/css';
-    link.rel = 'stylesheet';
-    link.id = stylesheetUrl;
-    link.href = stylesheetUrl;
-    root.appendChild(link);
-  } else {
-    logger.error(`Failed to inject css into consent manager!`);
-  }
-};
+export const injectCss = (stylesheetUrl: string): Promise<void> =>
+  new Promise((res) => {
+    const root = getAppContainer();
+    if (root && stylesheetUrl) {
+      const link = createHTMLElement<HTMLLinkElement>('link');
+      link.type = 'text/css';
+      link.rel = 'stylesheet';
+      link.id = stylesheetUrl;
+      link.href = stylesheetUrl;
+      link.addEventListener('load', () => res);
+      root.appendChild(link);
+    } else {
+      logger.error(`Failed to inject css into consent manager!`);
+    }
+  });

--- a/src/init.ts
+++ b/src/init.ts
@@ -84,7 +84,7 @@ export const init = async (): Promise<void> => {
     );
 
     // Inject CSS into the application
-    injectCss(settings.css || 'cm.css');
+    await injectCss(settings.css || 'cm.css');
 
     // Create the Transcend API
     const transcend: TranscendAPI = Object.assign(consentManagerAPI, {


### PR DESCRIPTION
## Changelog

This change makes it so we await the UI's CSS injection before moving on and processing the ready queue. More context on the change [here](https://github.com/transcend-io/consent-manager-tcf-ui/pull/104)