### PR TITLE
remove theme from playground config

### DIFF
--- a/src/playground/defaults.ts
+++ b/src/playground/defaults.ts
@@ -4,13 +4,9 @@ import type {
 } from '@transcend-io/airgap.js-types';
 import { DEFAULT_VIEW_STATE_BY_PRIVACY_REGIME_COPIED } from '../config';
 
-export const defaultConfig: ConsentManagerConfig = {
+export const defaultConfig: Partial<ConsentManagerConfig> = {
   css: './build/cm.css',
   messages: '',
-  theme: {
-    primaryColor: '#3333FF',
-    fontColor: '#010101',
-  },
   breakpoints: {
     tablet: '640px',
     desktop: '1024px',


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-31938

## Changelog

This config field was barely hooked up to anything since we allow custom stylesheets, so we're removing the field in the default config to prevent confusion (this was getting edited but since it doesn't really pass down to a lot of components people just thought the field was broken)