### PR TITLE
await breaks non-stubbed airgap

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/init.ts
+++ b/src/init.ts
@@ -84,7 +84,7 @@ export const init = async (): Promise<void> => {
     );
 
     // Inject CSS into the application
-    await injectCss(settings.css || 'cm.css');
+    injectCss(settings.css || 'cm.css');
 
     // Create the Transcend API
     const transcend: TranscendAPI = Object.assign(consentManagerAPI, {

--- a/src/init.ts
+++ b/src/init.ts
@@ -84,6 +84,8 @@ export const init = async (): Promise<void> => {
     );
 
     // Inject CSS into the application
+    // TODO: This should probably be awaited but it breaks non-stubbed airgap inits
+    // https://transcend.height.app/T-35913
     injectCss(settings.css || 'cm.css');
 
     // Create the Transcend API


### PR DESCRIPTION
## Changelog

awaiting the css injection breaks non-stubbed airgap for whatever reason. we weren't awaiting it before so i think this is fine to revert, but we should figure out whats going on here in the future. added a todo ticket to address it