### PR TITLE
turns out the comments are necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/cm.css
+++ b/src/cm.css
@@ -171,6 +171,7 @@ a:focus {
   word-wrap: break-word;
 }
 
+/** Style applied to the checkbox toggle box */
 .toggle-label input:focus + span {
   outline: 2px solid rgba(51, 157, 255, 0.7);
   outline-offset: 1px;


### PR DESCRIPTION
## Changelog

Turns out the comments in the css file are necessary for our parsing, so I've added one in to get this checkbox outline style parsing correctly