### PR TITLE
Csmccarthy/intl html substitution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.18.1",
+  "version": "4.18.2",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -69,7 +69,7 @@ export function App({
     });
 
   // Language setup
-  const { language, handleChangeLanguage, messages } = useLanguage({
+  const { language, handleChangeLanguage, messages, htmlTagVariables } = useLanguage({
     supportedLanguages,
     translationsLocation:
       // Order of priority:
@@ -121,7 +121,7 @@ export function App({
         {/** Ensure messages are loaded before any UI is displayed */}
         {messages ? (
           <Main
-            globalUiVariables={currentVariables}
+            globalUiVariables={{ ...currentVariables, ...htmlTagVariables }}
             airgap={airgap}
             modalOpenAuth={auth}
             viewState={viewState}

--- a/src/utils/substitute-html.ts
+++ b/src/utils/substitute-html.ts
@@ -1,0 +1,30 @@
+import { TranslatedMessages } from '@transcend-io/internationalization';
+
+/**
+ * Takes in a set of messages which may or may not contain HTML and replaces any
+ * HTML tags so that format.js can successfully internationalize them without
+ * running into parsing errors and using the fallback option
+ *
+ * @param messages - Raw precompiled messages (sometimes containing html tags)
+ * @returns Messages with all HTML opening/closing tags substituted and the variables to replace those substitutions
+ */
+export function substituteHtml(messages: TranslatedMessages): {
+  /** The set of messages with their HTML opening/closing tags substituted */
+  substitutedMessages: TranslatedMessages,
+  /** The set of variables used to replace the substitutions with their corresponding HTML opening/closing tags */
+  tagVariables: Record<string, string>
+} {
+  const substitutedMessages = { ...messages};
+  const tagVariables: Record<string, string> = {};
+  Object.entries(substitutedMessages).forEach(([key, rawMessage]) => {
+    let placeholderMessage = rawMessage;
+    const htmlTags = [...rawMessage.matchAll(/<[^>]+>/g)].flat()
+    htmlTags.forEach((tag, idx) => {
+      const uniqKey = key.replaceAll('.', '_');
+      placeholderMessage = placeholderMessage.replace(tag, `{tcm_${uniqKey}_tag_match_${idx}}`);
+      tagVariables[`tcm_${uniqKey}_tag_match_${idx}`] = tag
+    });
+    substitutedMessages[key] = placeholderMessage;
+  });
+  return { substitutedMessages, tagVariables };
+}


### PR DESCRIPTION
## Related Issues

- closes https://transcend.height.app/T-39521

## Changelog

Sending in variables with the message internalization function broke the CM UI messages we were trying to display, since format.js was attempting to parse the message as rich text (there is no HTML option as far as I could tell) and encountering a parsing error due to invalid tags. i.e. <a class="example"> was invalid because format.js can only substitute in HTML, not parse through it.

This should solve the issue by preprocessing our messages and removing HTML opening/closing tags, instead substituting them with format.js variables that we then replace during the internationalization process with the actual tags. For example:
we preprocess `Example text with a <a href="https://example.com">link</a>` to `Example text with a {var_to_substitute_1}link{var_to_substitute_2}` and then back to the original upon calling `formatMessage`.