### PR TITLE
add shadow root 'none'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/transcend-io/consent-manager-ui.git"
   },
   "homepage": "https://github.com/transcend-io/consent-manager-ui",
-  "version": "4.25.3",
+  "version": "4.25.4",
   "license": "MIT",
   "main": "build/ui",
   "files": [

--- a/src/consent-manager.tsx
+++ b/src/consent-manager.tsx
@@ -44,14 +44,17 @@ export const injectConsentManagerApp = async (
 
     try {
       const shadowRoot =
-        consentManager?.attachShadow?.({
-          mode:
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (mergedConfig.config.uiShadowRoot as any as
-              | undefined
-              | 'closed'
-              | 'open') || 'closed',
-        }) || consentManager;
+        mergedConfig.config.uiShadowRoot !== 'none' &&
+        consentManager?.attachShadow
+          ? consentManager.attachShadow({
+              mode:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (mergedConfig.config.uiShadowRoot as any as
+                  | undefined
+                  | 'closed'
+                  | 'open') || 'closed',
+            })
+          : consentManager;
 
       // Create an inner div for event listeners
       appContainer ??= createHTMLElement('div');


### PR DESCRIPTION
## Tickets
- closes https://linear.app/transcend/issue/GOOM-350/ada-banner-compliance-w-screen-readers

## Changelog

Adds a shadow root 'none' option, to prevent the UI from being created within a shadow root
