### PR TITLE
Remove Essential purpose from stub API for getConsent()

### DIFF
--- a/src/playground/airgapStub.ts
+++ b/src/playground/airgapStub.ts
@@ -67,9 +67,10 @@ export const airgapStub: AirgapAPI = {
     }
 
     const purposeTypes = getPurposeTypes();
-    delete purposeTypes.Essential;
     const purposes: Record<string, boolean> = {};
     Object.keys(purposeTypes).forEach((purpose) => {
+      // Not included in the response of getConsent()
+      if (purpose === 'Essential') return;
       purposes[purpose] = true;
     });
     return {

--- a/src/playground/airgapStub.ts
+++ b/src/playground/airgapStub.ts
@@ -67,6 +67,7 @@ export const airgapStub: AirgapAPI = {
     }
 
     const purposeTypes = getPurposeTypes();
+    delete purposeTypes.Essential;
     const purposes: Record<string, boolean> = {};
     Object.keys(purposeTypes).forEach((purpose) => {
       purposes[purpose] = true;


### PR DESCRIPTION
## Related Issues

- Closes [GOOM-359: Consent manager playground returns "Essential" in airgap.getConsent().purposes, but Essential is not returned on a real airgap bundle](https://linear.app/transcend/issue/GOOM-359/consent-manager-playground-returns-essential-in)

## Security Implications

_[none]_

## System Availability

_[none]_
